### PR TITLE
Fix leading whitespace if background is colored

### DIFF
--- a/src/Word.js
+++ b/src/Word.js
@@ -44,7 +44,8 @@ const StyledWordBackground = styled.rect`
 const StyledWord = styled.text`
   fill: ${TEXT_FILL};
   text-decoration: ${DECORATION};
-  font-weight: ${FONT_WEIGHT}
+  font-weight: ${FONT_WEIGHT};
+  white-space: pre;
 `;
 
 function bg(props, theme) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ const toViewModel = require('./to-view-model');
 const DEFAULT_THEME = require('./default-theme');
 
 const StyledContainer = styled.g`
-  font-family: ${props => props.fontFamily};
+  font-family: ${(props: any) => props.fontFamily};
 `;
 
 export interface SvgTermOptions {


### PR DESCRIPTION
Without this fix: 
<img width="838" alt="Screen Shot 2019-08-08 at 2 05 51 PM" src="https://user-images.githubusercontent.com/660288/62705648-b5c8dd00-b9e5-11e9-85e1-d4763b680a32.png">

With the fix:
<img width="842" alt="Screen Shot 2019-08-08 at 2 06 04 PM" src="https://user-images.githubusercontent.com/660288/62705664-beb9ae80-b9e5-11e9-90be-d43404fc73dd.png">

Cast file:
[pre-space-bug.cast.gz](https://github.com/marionebl/svg-term/files/3481860/pre-space-bug.cast.gz)


The fix might not be optimal, though, because the CSS tag is repeated. So feedback is welcome.