### PR TITLE
moved @emotion/styled and @emotion/core from dev dependencies to depe…

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "testURL": "http://localhost/"
   },
   "devDependencies": {
-    "@emotion/core": "^10.0.22",
-    "@emotion/styled": "^10.0.23",
     "@types/html-webpack-plugin": "^3.2.1",
     "@types/jest": "^24.0.18",
     "@types/lodash": "^4.14.149",
@@ -74,6 +72,8 @@
     "lodash": "^4.17.15",
     "object-hash": "^1.3.1",
     "react": "^16.10.2",
-    "react-dom": "^16.10.2"
+    "react-dom": "^16.10.2",
+    "@emotion/core": "^10.0.22",
+    "@emotion/styled": "^10.0.23"
   }
 }


### PR DESCRIPTION
…ndencies

Reason for this Pull Request
While setting up the project for the first time it gave cannot find module '@emotion/styled'.The reason is many of the source files
use @emotion/styled as it runtime dependency as opposed to its dev dependencies and currently the mentioned packages are specified in the devDependencies option in the package.json file.