### PR TITLE
Fix viewport overflow issues

### DIFF
--- a/src/Frame.tsx
+++ b/src/Frame.tsx
@@ -3,11 +3,12 @@ import * as React from 'react';
 export interface FrameProps {
   offset: number;
   width: number;
+  height: number;
 }
 
 export const Frame: React.FunctionComponent<FrameProps> = (props) => {
   return (
-    <svg x={props.offset * props.width}>
+    <svg x={props.offset * props.width} width={props.width} viewBox={`0 0 ${props.width} ${props.height}`}>
       <use xlinkHref="#a"/>
       {props.children}
     </svg>

--- a/src/Word.tsx
+++ b/src/Word.tsx
@@ -28,7 +28,7 @@ export const Word: React.FunctionComponent<WordProps> = props => {
           height={props.theme.fontSize * props.theme.lineHeight}
           inverse={props.inverse}
           width={props.children.length > 0 ? props.children.length : 0}
-          x={props.x * props.theme.fontSize * 0.6}
+          x={props.x}
           y={props.y - props.theme.fontSize}
         />
       )}
@@ -39,7 +39,7 @@ export const Word: React.FunctionComponent<WordProps> = props => {
         inverse={props.inverse}
         theme={props.theme}
         underline={props.underline}
-        x={props.x * props.theme.fontSize * 0.6}
+        x={props.x}
         y={props.y}
       >
         {props.children}

--- a/src/load-cast.ts
+++ b/src/load-cast.ts
@@ -11,7 +11,7 @@ export function loadCast(input: string, options: LoadOptions = {}): Cast {
   const { width, height, idle, fps } = options;
   return load(input, {
     width,
-    height: height ? height + 1 : undefined,
+    height,
     idle: idle ? idle / 1000 : undefined,
     fps
   });

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -48,7 +48,6 @@ export function render(
       paddingY={paddingY}
       decorations={decorations}
       cursor={cursor}
-      height={options.height}
     />
   );
 }

--- a/src/svg-term.tsx
+++ b/src/svg-term.tsx
@@ -42,14 +42,14 @@ export const SvgTerm: React.FunctionComponent<SvgTermProps> = props => {
   return (
     <Window
       decorations={props.decorations}
-      width={data.width}
+      width={data.displayWidth}
       height={data.displayHeight}
       background={props.theme.background}
       paddingX={props.paddingX}
       paddingY={props.paddingY}
     >
       <Document
-        width={data.width}
+        width={data.displayWidth}
         height={data.displayHeight}
         x={props.decorations ? 15 + props.paddingX : props.paddingX}
         y={props.decorations ? 50 + props.paddingY : props.paddingY}
@@ -67,7 +67,7 @@ export const SvgTerm: React.FunctionComponent<SvgTermProps> = props => {
             theme={props.theme}
           />
           <Background
-            width={data.width}
+            width={data.displayWidth}
             height={data.displayHeight}
             fill={props.theme.background}
           />

--- a/src/svg-term.tsx
+++ b/src/svg-term.tsx
@@ -17,7 +17,6 @@ export interface SvgTermProps {
   theme: Theme;
   paddingX: number;
   paddingY: number;
-  height?: number;
   decorations: boolean;
   from?: number;
   to?: number;
@@ -35,7 +34,6 @@ export const SvgTerm: React.FunctionComponent<SvgTermProps> = props => {
   const data = toViewModel({
     cast: props.cast,
     cursor: props.cursor,
-    height: props.height,
     theme: props.theme,
     from: from(bound),
     to: to(bound)

--- a/src/svg-term.tsx
+++ b/src/svg-term.tsx
@@ -81,7 +81,7 @@ export const SvgTerm: React.FunctionComponent<SvgTermProps> = props => {
           >
             {data.frames.map((frame: any, index: number) => {
               return (
-                <Frame key={frame.stamp} offset={index} width={data.width}>
+                <Frame key={frame.stamp} offset={index} width={data.displayWidth} height={data.displayHeight}>
                   {frame.cursor.visible && (
                     <use
                       xlinkHref="#b"

--- a/src/to-view-model.ts
+++ b/src/to-view-model.ts
@@ -10,7 +10,6 @@ export interface ViewModelOptions {
   from: number;
   to: number;
   theme: Theme;
-  height?: number;
 }
 
 export interface ViewModel {

--- a/src/to-view-model.ts
+++ b/src/to-view-model.ts
@@ -51,7 +51,6 @@ export function toViewModel(options: ViewModelOptions): ViewModel {
     .map(([stamp]) => stamp - from);
   const fontSize = theme.fontSize;
   const lineHeight = theme.lineHeight;
-  const height = typeof options.height === 'number' ? options.height : cast.height;
 
   const frames = loadedFrames
     .filter(([stamp]) => stamp >= from && stamp <= to)
@@ -108,7 +107,7 @@ export function toViewModel(options: ViewModelOptions): ViewModel {
     width: cast.width,
     displayWidth: cast.width,
     height: cast.height,
-    displayHeight: height * fontSize * lineHeight,
+    displayHeight: cast.height * fontSize * lineHeight,
     duration: to - from,
     registry,
     stamps,


### PR DESCRIPTION
Fix viewport overflow issues

Fix https://github.com/marionebl/svg-term-cli/issues/73
Fix https://github.com/marionebl/svg-term-cli/issues/78

Can be reviewed commit-by-commit (has a description of each fix)

(click to enlarge SVGs)

 - Notice as the second line of the first command is being typed out, the "chrom" overflow isn't cut-off on the right-side and there isn't an artifact from the previous frame on the left-side.
 - Notice that the terminal prompt is visible after each command (last line isn't cut-off)

Before | After
--- | ---
![](https://gist.githubusercontent.com/MadLittleMods/769045bf57fadc809ee335b4afadfb84/raw/6e899d839a8ddfb5957122dc01a82996e80455b3/demo-before.svg) | ![](https://gist.githubusercontent.com/MadLittleMods/769045bf57fadc809ee335b4afadfb84/raw/6e899d839a8ddfb5957122dc01a82996e80455b3/demo-after.svg)



## Testing strategy

Download [`demo.cast`](https://gist.githubusercontent.com/MadLittleMods/769045bf57fadc809ee335b4afadfb84/raw/6e899d839a8ddfb5957122dc01a82996e80455b3/demo.cast)

```sh
# Clone `svg-term`
$ git clone git@github.com:marionebl/svg-term.git
$ cd svg-term
$ git fetch origin refs/pull/43/head:pr-43
$ git checkout pr-43
$ npm install
$ npm run build
$ npm link
$ cd ..

# Now clone `svg-term-cli`
$ git clone git@github.com:marionebl/svg-term-cli.git
$ cd svg-term-cli
$ npm install
$ npm link svg-term
$ npm run build
$ npm link

# Generate a SVG
$ cat demo/demo.cast | svg-term --out demo/demo.svg --window --width=80 --height=24
```

